### PR TITLE
Change type of "Space Nerds In Space" from "clone" to "similar" (#614)

### DIFF
--- a/games/s.yaml
+++ b/games/s.yaml
@@ -494,8 +494,8 @@
   originals:
   - 'Artemis: Spaceship Bridge Simulator'
   repo: https://github.com/smcameron/space-nerds-in-space
-  type: clone
-  updated: 2018-08-05
+  type: similar
+  updated: 2019-03-06
   url: https://smcameron.github.io/space-nerds-in-space/
 
 - name: Space Station 14


### PR DESCRIPTION
* Change type of "Space Nerds In Space" from "clone" to "similar"

Clone means: genetically identical
http://lmgtfy.com/?q=define%3Aclone

SNIS shares zero DNA with Artemis, and is merely the same genre,
so it is cannot be a clone. Calling it a clone would be like calling
Star Wars a clone of Star Trek merely because they both have spaceships.

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>